### PR TITLE
Add element registrations for Argyris, Bell, Hermite, and Morley elements

### DIFF
--- a/test/test_sobolevspace.py
+++ b/test/test_sobolevspace.py
@@ -119,8 +119,8 @@ def test_contains_h1():
 
 def test_contains_h2():
     h2_elements = [
-        FiniteElement("ARG", triangle, 1),
-        FiniteElement("MOR", triangle),
+        FiniteElement("ARG", triangle, 5),
+        FiniteElement("MOR", triangle, 2),
     ]
     for h2_element in h2_elements:
         assert h2_element in H2
@@ -235,7 +235,7 @@ def test_varying_continuity_elements():
     P2 = FiniteElement("CG", interval, 2)
     P3 = FiniteElement("CG", interval, 3)
     RT1 = FiniteElement("RT", triangle, 1)
-    ARG = FiniteElement("ARG", triangle, 1)
+    ARG = FiniteElement("ARG", triangle, 5)
 
     # Tensor product elements
     P1DGP2 = TensorProductElement(P1DG_t, P2)

--- a/ufl/finiteelement/elementlist.py
+++ b/ufl/finiteelement/elementlist.py
@@ -134,7 +134,7 @@ register_element("Crouzeix-Raviart", "CR", 0, L2, "identity", (1, 1),
 # TODO: Implement generic Tear operator for elements instead of this:
 register_element("Discontinuous Raviart-Thomas", "DRT", 1, L2,
                  "contravariant Piola", (1, None), simplices[1:])
-register_element("Hermite", "HER", 0, H1, "identity", None, simplices[1:])
+register_element("Hermite", "HER", 0, H1, "identity", (3, None), simplices[1:])
 register_element("Mardal-Tai-Winther", "MTW", 0, H1, "identity", None,
                  ("triangle",))
 register_element("Morley", "MOR", 0, H2, "identity", None, ("triangle",))

--- a/ufl/finiteelement/elementlist.py
+++ b/ufl/finiteelement/elementlist.py
@@ -125,7 +125,7 @@ register_element("Raviart-Thomas", "RT", 1, HDiv, "contravariant Piola",
                  (1, None), simplices[1:])   # "RTF"  (2d), "N1F" (3d)
 
 # Elements not in the periodic table
-register_element("Argyris", "ARG", 0, H2, "identity", (1, None), simplices[1:])
+register_element("Argyris", "ARG", 0, H2, "identity", (5, None), ("triangle",) )
 register_element("Arnold-Winther", "AW", 0, H1, "identity", None, ("triangle",))
 register_element("Brezzi-Douglas-Fortin-Marini", "BDFM", 1, HDiv,
                  "contravariant Piola", (1, None), simplices[1:])

--- a/ufl/finiteelement/elementlist.py
+++ b/ufl/finiteelement/elementlist.py
@@ -137,7 +137,7 @@ register_element("Discontinuous Raviart-Thomas", "DRT", 1, L2,
 register_element("Hermite", "HER", 0, H1, "identity", (3, None), simplices[1:])
 register_element("Mardal-Tai-Winther", "MTW", 0, H1, "identity", None,
                  ("triangle",))
-register_element("Morley", "MOR", 0, H2, "identity", None, ("triangle",))
+register_element("Morley", "MOR", 0, H2, "identity", (2, None), ("triangle",))
 
 # Special elements
 register_element("Boundary Quadrature", "BQ", 0, L2, "identity", (0, None),

--- a/ufl/finiteelement/elementlist.py
+++ b/ufl/finiteelement/elementlist.py
@@ -125,8 +125,9 @@ register_element("Raviart-Thomas", "RT", 1, HDiv, "contravariant Piola",
                  (1, None), simplices[1:])   # "RTF"  (2d), "N1F" (3d)
 
 # Elements not in the periodic table
-register_element("Argyris", "ARG", 0, H2, "identity", (5, None), ("triangle",) )
+register_element("Argyris", "ARG", 0, H2, "identity", (5, None), ("triangle",))
 register_element("Arnold-Winther", "AW", 0, H1, "identity", None, ("triangle",))
+register_element("Bell", "BELL", 0, H2, "identity", (5, None), ("triangle",))
 register_element("Brezzi-Douglas-Fortin-Marini", "BDFM", 1, HDiv,
                  "contravariant Piola", (1, None), simplices[1:])
 register_element("Crouzeix-Raviart", "CR", 0, L2, "identity", (1, 1),

--- a/ufl/finiteelement/elementlist.py
+++ b/ufl/finiteelement/elementlist.py
@@ -125,9 +125,9 @@ register_element("Raviart-Thomas", "RT", 1, HDiv, "contravariant Piola",
                  (1, None), simplices[1:])   # "RTF"  (2d), "N1F" (3d)
 
 # Elements not in the periodic table
-register_element("Argyris", "ARG", 0, H2, "identity", (5, None), ("triangle",))
+register_element("Argyris", "ARG", 0, H2, "identity", (5, 5), ("triangle",))
 register_element("Arnold-Winther", "AW", 0, H1, "identity", None, ("triangle",))
-register_element("Bell", "BELL", 0, H2, "identity", (5, None), ("triangle",))
+register_element("Bell", "BELL", 0, H2, "identity", (5, 5), ("triangle",))
 register_element("Brezzi-Douglas-Fortin-Marini", "BDFM", 1, HDiv,
                  "contravariant Piola", (1, None), simplices[1:])
 register_element("Crouzeix-Raviart", "CR", 0, L2, "identity", (1, 1),
@@ -135,10 +135,10 @@ register_element("Crouzeix-Raviart", "CR", 0, L2, "identity", (1, 1),
 # TODO: Implement generic Tear operator for elements instead of this:
 register_element("Discontinuous Raviart-Thomas", "DRT", 1, L2,
                  "contravariant Piola", (1, None), simplices[1:])
-register_element("Hermite", "HER", 0, H1, "identity", (3, None), simplices[1:])
+register_element("Hermite", "HER", 0, H1, "identity", (3, 3), simplices[1:])
 register_element("Mardal-Tai-Winther", "MTW", 0, H1, "identity", None,
                  ("triangle",))
-register_element("Morley", "MOR", 0, H2, "identity", (2, None), ("triangle",))
+register_element("Morley", "MOR", 0, H2, "identity", (2, 2), ("triangle",))
 
 # Special elements
 register_element("Boundary Quadrature", "BQ", 0, L2, "identity", (0, None),


### PR DESCRIPTION
The current FInAT/tsfc implementation only supports:

- Argyris degree 5
- Hermite degree 3
- Morley degree 2
- Bell degree 5

And so those are the only valid values right now (could be changed).

But I think some of these elements have general constructions (with some minimum degree).  