### PR TITLE
pullback tensor vector valued

### DIFF
--- a/ufl/algorithms/apply_function_pullbacks.py
+++ b/ufl/algorithms/apply_function_pullbacks.py
@@ -33,6 +33,7 @@ from ufl.classes import (ReferenceValue,
 
 from ufl.tensors import as_tensor, as_vector
 from ufl.utils.sequences import product
+import numpy
 
 
 def sub_elements_with_mappings(element):
@@ -146,14 +147,12 @@ def apply_single_function_pullbacks(g):
     #     (ONLY IF REFERENCE VALUE SHAPE PRESERVES TENSOR RANK)
     #   - All cases with scalar subelements and without symmetries are
     #     covered by the shortcut above
-    # - VectorElements of vector-valued basic elements (FIXME)
-    # - TensorElements with symmetries (FIXME)
-    assert len(gsh) == 1
-    assert len(rsh) == 1
 
     g_components = [None] * gsize
     gpos = 0
     rpos = 0
+
+    r = as_vector([r[idx] for idx in numpy.ndindex(r.ufl_shape)])
     for subelm in sub_elements_with_mappings(element):
         gm = product(subelm.value_shape())
         rm = product(subelm.reference_value_shape())
@@ -234,8 +233,7 @@ def apply_single_function_pullbacks(g):
 
     # Wrap up components in a vector, must return same shape as input
     # function g
-    assert len(gsh) == 1
-    f = as_vector(g_components)
+    f = as_tensor(numpy.asarray(g_components).reshape(gsh))
     assert f.ufl_shape == g.ufl_shape
     return f
 

--- a/ufl/finiteelement/mixedelement.py
+++ b/ufl/finiteelement/mixedelement.py
@@ -361,9 +361,6 @@ class TensorElement(MixedElement):
             # Create scalar sub element
             sub_element = FiniteElement(family, cell, degree, quad_scheme=quad_scheme)
 
-        if sub_element.value_shape() != ():
-            error("Expecting only scalar valued subelement for TensorElement.")
-
         # Set default shape if not specified
         if shape is None:
             if cell is None:
@@ -424,6 +421,8 @@ class TensorElement(MixedElement):
             reference_value_shape = shape
             self._mapping = "identity"
 
+        value_shape = value_shape + sub_element.value_shape()
+        reference_value_shape = reference_value_shape + sub_element.reference_value_shape()
         # Initialize element data
         MixedElement.__init__(self, sub_elements, value_shape=value_shape,
                               reference_value_shape=reference_value_shape)


### PR DESCRIPTION
Add appropriate symbolic support for pullback of vector or tensor-valued spaces (e.g. `VectorElement(BDM)`).

Just spins over all the individual components.