### PR TITLE
External Operators

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [flake8]
-ignore = E501, W504
+ignore = E501, W504,
+         E741                   # ambiguous variable name
 builtins = ufl
 exclude = .git,__pycache__,doc/sphinx/source/conf.py,build,dist,test
 


### PR DESCRIPTION
This PR follows the discussion initiated here: #15 , cf. the following PR #16 

`ExternalOperator` is a subclass of `Coefficient` which carries operands and a derivative multi-index. Its purposes is to enable the incorporation in a form of operators that are not directly expressible in UFL. A number of important classes of function fall into this category:

 - Implicit constitutive relations. I.e. nonlinear solids or fluids where the stress is computed by solving a point wise nonlinear equation every time the operator is evaluated.

 - Explicit functions not easily written in UFL such as neural nets which might be used in learned parametrisations or learned regularisers for inverse problems.

 - Parametrisations which are inconvenient to write in UFL because they, for example, contain a lot of switching and interpolation from lookup tables.


`ufl.ExternalOperator` handles the symbolic side (e.g. differentiation), a practical implementation is needed to state how does one correlate the operands to evaluate the `ExternalOperator`. 

This practical implementation is already implemented in Firedrake: see https://github.com/firedrakeproject/firedrake/pull/1674

The implementation of the adjoint capability is also already done, enabling to tackle more generally PDE-constrained optimization problems.

Examples of applications cover:

    - Implicit constitutive relations (e.g. Glen's flow law in glaciology)
    - Regularizer for inverse problems (e.g. seismic inversion)
    - Subgrid parametrization


Mathematically, an `ExternalOperator` **N** can be defined as follows:

    V_1 x ... x V_k --> X
         u1, ..., uk |--> N(u1, ..., uk)

where `u1, ..., uk` are Coefficients belonging respectively to the function spaces `V_1, ..., V_k`, and where X is the function space associated to the external operator `N`.

In practice, when assembling a form containing `N`, we:

  - Interpolate the operands (u1, ..., uk) into X
  - Evaluate N(u1^{X}, ..., uk^{X})

Obviously, we need to explicitly define how to evaluate `N`, this is done at the Firedrake stage where we have an `AbstractPointwiseOperator` class that subclasses `ExternalOperator` and that provides a method to evaluate the `ExternalOperator`.

For instance, for the implicit constitutive law example the evaluate method will solve the nonlinear constitutive law pointwisely.

For the explicit function case, here is toy example illustrating how looks the pseudo code to solve the poisson's equation with a rhs `f` where `inner(u-f, v)` is replaced by `inner(p2, v)`:

    ...
    V = FunctionSpace(...)
    ...
    u = Function(V)
    ...
    p = point_expr(lambda x, y: x - y, function_space=V)
    p2 = p(u, f)
    ...
    F = inner(grad(p2), grad(v) * dx + inner(p2, v) * dx
    solve(F == 0, u, ...)
    ...