### PR TITLE
changing name from kmv to mlt

### DIFF
--- a/ufl/finiteelement/elementlist.py
+++ b/ufl/finiteelement/elementlist.py
@@ -116,7 +116,7 @@ register_element("Crouzeix-Raviart", "CR", 0, L2, "identity", (1, 1),
 register_element("Discontinuous Raviart-Thomas", "DRT", 1, L2,
                  "contravariant Piola", (1, None), simplices[1:])
 register_element("Hermite", "HER", 0, H1, "identity", (3, 3), simplices)
-register_element("Kong-Mulder-Veldhuizen", "KMV", 0, H1, "identity", (1, None),
+register_element("Mass lumped triangles and tetrahedra", "MLT", 0, H1, "identity", (1, None),
                  simplices[1:])
 register_element("Mardal-Tai-Winther", "MTW", 1, H1, "contravariant Piola", (3, 3),
                  ("triangle",))


### PR DESCRIPTION
This PR was made just to rename the KMV elements. KMV is a bit of a misnomer, since the last name of the first author of the cited paper is actually Chin-Joe-Kong (https://link.springer.com/article/10.1023/A:1004420829610).

Also, since this type of higher order triangular mass lumped triangular elements for the wave equation has been the subject of many papers getting the name of every researcher involved would be quite a list, therefore, I propose we just follow the nomenclature from the articles the used quadrature points come from and call them MLT.

Articles:
> Higher-order triangular and tetrahedral finite elements with mass
>  lumping for solving the wave equation
>  M. J. S. CHIN-JOE-KONG, W. A. MULDER and M. VAN VELDHUIZEN
>
>  Higher-order Mass-lumped Finite Elements for the Wave Equation
>  W.A. MULDER
>
>  New Higher-order Mass-lumped Tetrahedral Elements
>  S. GEEVERS, W.A. MULDER, AND J.J.W. VAN DER VEGT

The related PRs for TSFC, FIAT, Firedrake, and FInAT are forthcoming.
Kind regards,

## Associated Pull Requests:
- [firedrake PR#2945](https://github.com/firedrakeproject/firedrake/pull/2945)
- [tsfc PR#295](https://github.com/firedrakeproject/tsfc/pull/295)
- [fiat PR#38](https://github.com/firedrakeproject/fiat/pull/38)
- [finat PR#110](https://github.com/FInAT/FInAT/pull/110)