### PR TITLE
Product rule for derivative of a FormSum

### DIFF
--- a/ufl/formoperators.py
+++ b/ufl/formoperators.py
@@ -311,7 +311,7 @@ def derivative(form, coefficient, argument=None, coefficient_derivatives=None):
         args = [(derivative(component, coefficient, argument, coefficient_derivatives), weight)
                 for component, weight in zip(components, weights)
                 if coefficient in component.coefficients()]
-        args += [(component, derivative(weight, coefficient, argument, coefficient_derivatives))
+        args += [(component * derivative(weight, coefficient, argument, coefficient_derivatives)), 1
                  for component, weight in zip(components, weights)
                  if hasattr(weight, "coefficients") and coefficient in weight.coefficients()]
         if len(args) == 1:

--- a/ufl/formoperators.py
+++ b/ufl/formoperators.py
@@ -311,7 +311,7 @@ def derivative(form, coefficient, argument=None, coefficient_derivatives=None):
         args = [(derivative(component, coefficient, argument, coefficient_derivatives), weight)
                 for component, weight in zip(components, weights)
                 if coefficient in component.coefficients()]
-        args += [(component * derivative(weight, coefficient, argument, coefficient_derivatives)), 1
+        args += [(component * derivative(weight, coefficient, argument, coefficient_derivatives), 1)
                  for component, weight in zip(components, weights)
                  if hasattr(weight, "coefficients") and coefficient in weight.coefficients()]
         if len(args) == 1:


### PR DESCRIPTION
Adding the product rule for `FormSum` (although I know that so far we only support constant weights). 

In addition, we eagerly cancel terms that are zero by checking if they depend on the variable with respect to which we are differentiating. 

Also this fixes [Firedrake issue #3206](https://github.com/firedrakeproject/firedrake/issues/3206), as we do not return a `FormSum` when the variational term is the only one that depends on the differentiation variable. 